### PR TITLE
fix: join us button click area

### DIFF
--- a/src/components/LXDAOIntroduction.tsx
+++ b/src/components/LXDAOIntroduction.tsx
@@ -1,12 +1,12 @@
-import React from "react";
+import React from 'react';
 
-import styled, { keyframes } from "styled-components";
-import { Box, Typography, Link } from "@mui/material";
+import styled, { keyframes } from 'styled-components';
+import { Box, Typography, Link } from '@mui/material';
 
-import LXDAOLogo from "./LXDAOLogo";
-import twitterCircle from "../assets/icon/twitter-circle.svg";
-import discordCircle from "../assets/icon/discord-circle.svg";
-import forumCircle from "../assets/icon/forum-circle.svg";
+import LXDAOLogo from './LXDAOLogo';
+import twitterCircle from '../assets/icon/twitter-circle.svg';
+import discordCircle from '../assets/icon/discord-circle.svg';
+import forumCircle from '../assets/icon/forum-circle.svg';
 
 const textColorGradient = keyframes`
     0%{background-position:0% 50%}
@@ -36,20 +36,20 @@ const HightlightText = styled.span`
 const CommunityLinkGroup = () => (
   <Box display="flex" gap={2} marginBottom={10}>
     <Link href="https://twitter.com/LXDAO_Official" target="_blank">
-      <Box component={"img"} src={twitterCircle} />
+      <Box component={'img'} src={twitterCircle} />
     </Link>
     <Link href="https://discord.lxdao.io" target="_blank">
-      <Box component={"img"} src={discordCircle} />
+      <Box component={'img'} src={discordCircle} />
     </Link>
     <Link href="https://forum.lxdao.io/" target="_blank">
-      <Box component={"img"} src={forumCircle} />
+      <Box component={'img'} src={forumCircle} />
     </Link>
   </Box>
 );
 
 const LXDAOIntroduction = ({
-  maxWidth = "1216px",
-  xsWidth = "350px",
+  maxWidth = '1216px',
+  xsWidth = '350px',
   ...restProps
 }: any) => {
   const Title = () => {
@@ -60,7 +60,7 @@ const LXDAOIntroduction = ({
             textTransform="uppercase"
             color="#365AE2"
             lineHeight="44px"
-            sx={{ fontWeight: "600 !important", fontSize: "12px !important" }}
+            sx={{ fontWeight: '600 !important', fontSize: '12px !important' }}
           >
             Honor-produced by <LXDAOLogo height="16px" width="58.67px" />
           </Typography>
@@ -68,7 +68,7 @@ const LXDAOIntroduction = ({
             textTransform="uppercase"
             color="#141414"
             lineHeight="53px"
-            sx={{ fontWeight: "700 !important", fontSize: "44px !important" }}
+            sx={{ fontWeight: '700 !important', fontSize: '44px !important' }}
           >
             LXDAO is an <HightlightText>R&amp;D</HightlightText>-
           </Typography>
@@ -77,7 +77,7 @@ const LXDAOIntroduction = ({
             color="#141414"
             lineHeight="53px"
             letterSpacing="0"
-            sx={{ fontWeight: "700 !important", fontSize: "44px !important" }}
+            sx={{ fontWeight: '700 !important', fontSize: '44px !important' }}
           >
             focused DAO in Web3
           </Typography>
@@ -90,47 +90,47 @@ const LXDAOIntroduction = ({
     <Box
       maxWidth={maxWidth}
       boxSizing="border-box"
-      marginX={{ lg: "auto", md: "20px", xs: "20px" }}
-      minHeight={{ md: "403px", xs: "403px" }}
+      marginX={{ lg: 'auto', md: '20px', xs: '20px' }}
+      minHeight={{ md: '403px', xs: '403px' }}
       display="flex"
-      flexDirection={{ lg: "row", xs: "column" }}
+      flexDirection={{ lg: 'row', xs: 'column' }}
       justifyContent="flex-start"
       alignItems="center"
       textAlign="center"
-      gap={{ lg: "120px", xs: "40px" }}
+      gap={{ lg: '120px', xs: '40px' }}
     >
       <Box
         display="flex"
-        flexDirection={{ md: "row", xs: "column-reverse" }}
+        flexDirection={{ md: 'row', xs: 'column-reverse' }}
         gap={6}
         alignItems="center"
         textAlign="left"
       >
         <Box
           crossOrigin="anonymous"
-          component={"img"}
-          width={{ xs: xsWidth, sm: "auto" }}
+          component={'img'}
+          width={{ xs: xsWidth, sm: 'auto' }}
           src="https://api.lxdao.io/lxdao/lxdaoIntroduction"
         />
         <Box
           display="flex"
           flexDirection="column"
           gap={4}
-          width={{ xs: xsWidth, sm: "auto" }}
+          width={{ xs: xsWidth, sm: 'auto' }}
           alignItems="flex-start"
           textAlign="left"
         >
           <Title />
-          <Box display={{ md: "block", sm: "none", xs: "none" }}>
+          <Box display={{ md: 'block', sm: 'none', xs: 'none' }}>
             <Typography
-              sx={{ fontSize: "21px !important" }}
+              sx={{ fontSize: '21px !important' }}
               lineHeight="29px"
               color="#667085"
             >
               Our mission is bringing together buidlers to buidl and
             </Typography>
             <Typography
-              sx={{ fontSize: "21px !important" }}
+              sx={{ fontSize: '21px !important' }}
               lineHeight="29px"
               color="#667085"
             >
@@ -138,9 +138,9 @@ const LXDAOIntroduction = ({
               manner.
             </Typography>
           </Box>
-          <Box display={{ md: "none", sm: "block", xs: "block" }}>
+          <Box display={{ md: 'none', sm: 'block', xs: 'block' }}>
             <Typography
-              sx={{ fontSize: "21px !important" }}
+              sx={{ fontSize: '21px !important' }}
               lineHeight="29px"
               color="#667085"
             >
@@ -154,39 +154,40 @@ const LXDAOIntroduction = ({
             justifyContent="space-between"
             height="48px"
           >
-            <Box
-              display="flex"
-              alignItems="center"
-              justifyContent="center"
-              width="180px"
+            <Link
+              target="_blank"
+              href={`https://lxdao.io/joinus`}
+              color="#ffffff"
               sx={{
-                cursor: "pointer",
-                "&:hover": {
-                  backgroundColor: "rgba(0, 0, 0, 0.8)",
-                },
-                color: "#ffffff",
-                borderRadius: "6px",
-                border: "none",
-                outline: "none",
-                padding: "12px 20px",
-                fontSize: "16px",
-                lineHeight: "24px",
-                fontWeight: "600",
-                background: "linear-gradient(90deg, #305FE8 0%, #3AD9E3 100%)",
+                textDecoration: 'none',
+                marginBottom: 0,
               }}
             >
-              <Link
-                target="_blank"
-                href={`https://lxdao.io/joinus`}
-                color="#ffffff"
+              <Box
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
+                width="180px"
                 sx={{
-                  textDecoration: "none",
-                  marginBottom: 0,
+                  cursor: 'pointer',
+                  '&:hover': {
+                    backgroundColor: 'rgba(0, 0, 0, 0.8)',
+                  },
+                  color: '#ffffff',
+                  borderRadius: '6px',
+                  border: 'none',
+                  outline: 'none',
+                  padding: '12px 20px',
+                  fontSize: '16px',
+                  lineHeight: '24px',
+                  fontWeight: '600',
+                  background:
+                    'linear-gradient(90deg, #305FE8 0%, #3AD9E3 100%)',
                 }}
               >
                 JOIN US
-              </Link>
-            </Box>
+              </Box>
+            </Link>
             <CommunityLinkGroup />
           </Box>
         </Box>


### PR DESCRIPTION
<img width="467" alt="image" src="https://user-images.githubusercontent.com/100744989/211012611-c85beddd-d8ab-4dcc-9756-36531864667d.png">
click the whole button instead of only the button text will redirect to the join us page